### PR TITLE
Fix save() to declare UTF-8 charset in saved HTML

### DIFF
--- a/python/lightgraph/network.py
+++ b/python/lightgraph/network.py
@@ -30,12 +30,21 @@ class NetworkVisualization:
         """The raw HTML content as a string."""
         return self._html
 
-    def _repr_html_(self) -> str:
-        """Jupyter rich display: renders in an iframe for DOM isolation."""
-        full_html = (
+    def _full_document(self) -> str:
+        """Wrap the raw fragment in a standalone HTML document with an
+        explicit UTF-8 charset declaration. Without this, a file opened
+        directly in a browser/editor (no HTTP Content-Type header, no BOM)
+        has its encoding guessed, which mangles the non-ASCII characters
+        lightGraph's own UI uses (e.g. the legend bullet '●') into mojibake.
+        """
+        return (
             "<!DOCTYPE html><html><head><meta charset='utf-8'></head>"
             f"<body style='margin:0;padding:0;overflow:hidden;'>{self._html}</body></html>"
         )
+
+    def _repr_html_(self) -> str:
+        """Jupyter rich display: renders in an iframe for DOM isolation."""
+        full_html = self._full_document()
         b64 = base64.b64encode(full_html.encode('utf-8')).decode('ascii')
         uid = uuid.uuid4().hex[:8]
         return (
@@ -63,7 +72,7 @@ class NetworkVisualization:
     def save(self, filepath: str) -> None:
         """Save the visualization as a standalone HTML file."""
         with open(filepath, 'w', encoding='utf-8') as f:
-            f.write(self._html)
+            f.write(self._full_document())
 
 
 def _edges_from_dense(adj_matrix, node_names, dedup_symmetric):


### PR DESCRIPTION
Fixes #9.

`save()` wrote the raw HTML fragment directly to disk with no `<!DOCTYPE html>`, no `<head>`, and no `<meta charset="utf-8">`. That fragment contains legitimate UTF-8 characters from lightGraph's own bundled UI (e.g. the `●` bullet prefixing each legend entry), which get mangled into mojibake by browsers/editors guessing the encoding of a charset-less local file.

`_repr_html_()` (the Jupyter iframe path) already wrapped the same fragment in a full document with an explicit charset before embedding it in the iframe `srcdoc` — so notebook rendering was unaffected. Only the `save()`-to-file path was missing it.

This factors that wrapping into a shared `_full_document()` helper and uses it in both places, so the two paths stay consistent instead of duplicating (and drifting from) the same string.

Tested locally: saved HTML now opens correctly in a browser with the legend/UI characters rendering as intended instead of mojibake.
